### PR TITLE
Remove redundant dependency

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -52,9 +52,7 @@
   "peerDependencies": {
     "react": "^0.14.7 || ^15.0.0"
   },
-  "dependencies": {
-    "babel-runtime": "^6.5.0"
-  },
+  "dependencies": {},
   "main": "dist/index.js",
   "engines": {
     "npm": "^3.0.0"


### PR DESCRIPTION
`babel-runtime` is a dependency of `@kadira/storybook`
