### PR TITLE
fix: add webpack-hot-middleware as dev dependency

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -47,7 +47,8 @@
     "@kadira/storybook": "^1.19.0",
     "style-loader": "^0.13.1",
     "raw-loader": "^0.5.1",
-    "git-url-parse": "^6.0.1"
+    "git-url-parse": "^6.0.1",
+    "webpack-hot-middleware": "^2.10.0"
   },
   "peerDependencies": {
     "react": "^0.14.7 || ^15.0.0"


### PR DESCRIPTION
Without the dependency installed, the following error will show:

ERROR in multi preview
Module not found: Error: Cannot resolve module 'webpack-hot-middleware/client' in /Users/ali/mydev/cdk-story-book/react-wizard
 @ multi preview
