### PR TITLE
Use the --copy-files option with babel

### DIFF
--- a/generators/app/templates/.scripts/prepublish.sh
+++ b/generators/app/templates/.scripts/prepublish.sh
@@ -9,7 +9,7 @@
 echo "=> Transpiling 'src' into ES5 ..."
 echo ""
 rm -rf ./dist
-NODE_ENV=production ./node_modules/.bin/babel --ignore tests,stories --plugins "transform-runtime" ./src --out-dir ./dist
+NODE_ENV=production ./node_modules/.bin/babel --ignore tests,stories --plugins "transform-runtime" --copy-files ./src --out-dir ./dist
 echo ""
 echo "=> Transpiling completed."
 


### PR DESCRIPTION
In case you are using file loaders or css/sass/scss/less/etc loaders with your webpack and you want to use this component in a project that also has those loaders, you have to copy those assets to the `dist` directory as well, so the webpack on the parent project can find them and compile the bundle. If you don't have any of those using the option will not hurt.
